### PR TITLE
Add auto-server creation

### DIFF
--- a/root/serverpanel/backend/main.py
+++ b/root/serverpanel/backend/main.py
@@ -2,7 +2,13 @@ from fastapi import APIRouter, FastAPI, Request, HTTPException, Depends, Header,
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from auth import verify_license
-from services import list_services, control_service, get_logs, list_server_names
+from services import (
+    list_services,
+    control_service,
+    get_logs,
+    list_server_names,
+    create_server,
+)
 from licenses_api import router as license_router
 import sqlite3
 from filemanager import router as filemanager_router
@@ -86,3 +92,15 @@ def delete_files(data: DeleteRequest, api_key: str = Depends(verify_license)):
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Fehler beim Löschen: {rel}: {str(e)}")
     return {"deleted": deleted}
+
+
+class CreateServerRequest(BaseModel):
+    name: str
+    ram_mb: int
+    jar_path: str = "/var/www/html/ck-website/server.jar"
+    rcon_password: str | None = ""
+
+
+@app.post("/create")
+def create_server_endpoint(data: CreateServerRequest, api_key: str = Depends(verify_license)):
+    return create_server(data.name, data.ram_mb, data.jar_path, data.rcon_password or "")

--- a/root/serverpanel/backend/services.py
+++ b/root/serverpanel/backend/services.py
@@ -3,6 +3,7 @@ import psutil
 import re
 import socket
 import struct
+import os
 from mcrcon import MCRcon
 
 def read_port_mapping(path="/etc/mc-ports.txt"):
@@ -187,3 +188,14 @@ def get_player_count_rcon(host, port, password):
                 return int(match.group(1))
     except:
         return None
+
+
+def create_server(name, ram_mb, jar_path="/var/www/html/ck-website/server.jar", rcon_password=""):
+    """Create a new Minecraft server using the install script."""
+    cmd = ["/root/serverpanel/install_minecraft_server.sh"]
+    input_data = f"{name}\n{ram_mb}\n{jar_path}\n{rcon_password}\n"
+    try:
+        subprocess.run(cmd, input=input_data, text=True, check=True)
+        return {"success": True}
+    except subprocess.CalledProcessError as e:
+        return {"success": False, "error": e.stderr}

--- a/var/www/html/ck-website/save_project.php
+++ b/var/www/html/ck-website/save_project.php
@@ -37,6 +37,23 @@ if ($result === FALSE) {
 }
 
 $response = json_decode($result, true);
+
+// Nach erfolgreichem Speichern den Server automatisch erstellen
+$serverpanel_url = "http://localhost:8001/create";
+$server_data = [
+    "name" => $project_name,
+    "ram_mb" => $ram * 1024,
+    "jar_path" => "/var/www/html/ck-website/server.jar"
+];
+$sp_options = [
+    'http' => [
+        'header'  => "Content-Type: application/json\r\nx-api-key: h2r-admin0709-reload9383\r\n",
+        'method'  => 'POST',
+        'content' => json_encode($server_data),
+    ],
+];
+$sp_context = stream_context_create($sp_options);
+@file_get_contents($serverpanel_url, false, $sp_context);
 ?>
 
 <h1>Projekt gespeichert!</h1>


### PR DESCRIPTION
## Summary
- create API endpoint to spin up a server
- run install script when a project is created
- trigger server creation from the website when saving projects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844dbb9e7c08324a3af8bc816e54b2e